### PR TITLE
Allow reusing Home struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -76,7 +76,9 @@ type HotwaterParStruct struct {
 	Index int
 }
 
-type Homes []struct {
+type Homes []Home
+
+type Home struct {
 	HomeName string `json:"homeName"`
 	Address  struct {
 		Street      string `json:"street"`


### PR DESCRIPTION
Required for https://github.com/evcc-io/evcc/pull/24718. It would also by nice if `GetHomes` could just return `[]Home` instead of another type.